### PR TITLE
Use table nodes to store Perk Evaluator metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,14 @@ set(MODULE_SRCS
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.cxx
   qSlicer${MODULE_NAME}ModuleWidget.h
+  qSlicerTablesReader.cxx
+  qSlicerTablesReader.h
   )
 
 set(MODULE_MOC_SRCS
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.h
+  qSlicerTablesReader.h
   )
 
 set(MODULE_UI_SRCS

--- a/Logic/vtkSlicerPerkEvaluatorLogic.cxx
+++ b/Logic/vtkSlicerPerkEvaluatorLogic.cxx
@@ -5,6 +5,8 @@
 // MRML includes
 #include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLTransformNode.h"
+#include "vtkMRMLTableNode.h"
+#include "vtkMRMLTableStorageNode.h"
 
 // VTK includes
 #include <vtkDataArray.h>
@@ -101,6 +103,8 @@ void vtkSlicerPerkEvaluatorLogic
     this->ToolTrajectories.at(i).Buffer->Delete();
   }
   this->ToolTrajectories.clear();
+
+  this->MetricsNode = NULL;
 }
 
 
@@ -146,6 +150,13 @@ void vtkSlicerPerkEvaluatorLogic
   vtkMRMLPerkEvaluatorNode* peNode = vtkMRMLPerkEvaluatorNode::New();
   this->GetMRMLScene()->RegisterNodeClass( peNode );
   peNode->Delete();
+
+  vtkMRMLTableNode* tNode = vtkMRMLTableNode::New();
+  this->GetMRMLScene()->RegisterNodeClass( tNode );
+  tNode->Delete();
+  vtkMRMLTableStorageNode* tsNode = vtkMRMLTableStorageNode::New();
+  this->GetMRMLScene()->RegisterNodeClass( tsNode );
+  tsNode->Delete();
 }
 
 
@@ -172,19 +183,18 @@ void vtkSlicerPerkEvaluatorLogic
 // -----------------------------------------------------------------------------------
 
 
-std::vector<vtkSlicerPerkEvaluatorLogic::MetricType> vtkSlicerPerkEvaluatorLogic
+vtkMRMLTableNode* vtkSlicerPerkEvaluatorLogic
 ::GetMetrics( vtkMRMLPerkEvaluatorNode* peNode )
 {
-  std::vector<MetricType> metrics;
 
   // Check conditions
   if ( peNode == NULL )
   {
-    return metrics;
+    return NULL;
   }
   if ( peNode->GetMarkBegin() >= peNode->GetMarkEnd() ) // Is a test for to see if the MarkBegin and MarkEnd are within the bounds of the procedure time really necessary?
   {
-    return metrics;
+    return NULL;
   }
 
   // Use the python metrics calculator module
@@ -192,22 +202,10 @@ std::vector<vtkSlicerPerkEvaluatorLogic::MetricType> vtkSlicerPerkEvaluatorLogic
   pythonManager->executeString( "import PythonMetricsCalculator" );
   pythonManager->executeString( "PythonMetricsCalculatorLogic = PythonMetricsCalculator.PythonMetricsCalculatorLogic()" );
   pythonManager->executeString( QString( "PythonMetricsCalculatorLogic.SetPerkEvaluatorNodeID( '%1' )" ).arg( peNode->GetID() ) );
-  pythonManager->executeString( "PythonMetricsVariable = PythonMetricsCalculatorLogic.CalculateAllMetrics()" );
-  QVariant result = pythonManager->getVariable( "PythonMetricsVariable" );
-  QStringList pythonMetrics = result.toStringList();
+  pythonManager->executeString( QString( "PythonMetricsCalculatorLogic.SetMetricsNodeID( '%1' )" ).arg( this->MetricsNode->GetID() ) );
+  pythonManager->executeString( "PythonMetricsCalculatorLogic.CalculateAllMetrics()" );
 
-  int i = 0;
-  while ( i < pythonMetrics.length() )
-  {
-    MetricType currentPythonMetric;
-    currentPythonMetric.first = pythonMetrics.at( i ).toStdString();
-    currentPythonMetric.second = atof( pythonMetrics.at( i + 1 ).toStdString().c_str() );
-    metrics.push_back( currentPythonMetric );
-    i = i + 2;
-  }
-
-
-  return metrics;
+  return this->MetricsNode;
 }
 
 
@@ -247,6 +245,42 @@ void vtkSlicerPerkEvaluatorLogic
     currentTrajectory.Buffer = toolBuffers.at(i);
     this->ToolTrajectories.push_back( currentTrajectory );
 
+  }
+
+  this->FindOrCreateMetricsNode( bufferNode );
+
+}
+
+
+void vtkSlicerPerkEvaluatorLogic
+::FindOrCreateMetricsNode( vtkMRMLTransformBufferNode* bufferNode )
+{
+  // Also, find the metrics table node associated with the buffer  
+  this->MetricsNode = NULL;
+
+  vtkSmartPointer< vtkCollection > tableNodes = this->GetMRMLScene()->GetNodesByClass( "vtkMRMLTableNode" );
+  for ( int i = 0; i < tableNodes->GetNumberOfItems(); i++ )
+  {
+    vtkMRMLTableNode* currentNode = vtkMRMLTableNode::SafeDownCast( tableNodes->GetItemAsObject( i ) );
+    if ( currentNode == NULL )
+    {
+      continue;
+    }
+
+    if ( strcmp( currentNode->GetNodeReferenceID( "TransformBuffer" ), bufferNode->GetID() ) == 0 )
+    {
+      this->MetricsNode = currentNode;
+    }
+  }
+
+  if ( this->MetricsNode == NULL )
+  {
+    vtkSmartPointer< vtkMRMLTableNode > newMetricsNode;
+    newMetricsNode.TakeReference( vtkMRMLTableNode::SafeDownCast( this->GetMRMLScene()->CreateNodeByClass( "vtkMRMLTableNode" ) ) );
+    newMetricsNode->SetScene( this->GetMRMLScene() );
+    newMetricsNode->SetNodeReferenceID( "TransformBuffer", bufferNode->GetID() );
+    this->GetMRMLScene()->AddNode( newMetricsNode );
+    this->MetricsNode = newMetricsNode;
   }
 
 }

--- a/Logic/vtkSlicerPerkEvaluatorLogic.h
+++ b/Logic/vtkSlicerPerkEvaluatorLogic.h
@@ -16,7 +16,9 @@
 #include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLModelNode.h"
 #include "vtkMRMLModelDisplayNode.h"
+#include "vtkMRMLTableNode.h"
 #include "vtkMRMLPerkEvaluatorNode.h"
+
 
 // STD includes
 #include <cstdlib>
@@ -81,7 +83,7 @@ public:
   void SetPlaybackTime( double time );
 
   typedef std::pair<std::string,double> MetricType;  
-  std::vector<MetricType> GetMetrics( vtkMRMLPerkEvaluatorNode* peNode );
+  vtkMRMLTableNode* GetMetrics( vtkMRMLPerkEvaluatorNode* peNode );
 
   vtkSlicerTransformRecorderLogic* TransformRecorderLogic;  
   
@@ -95,6 +97,9 @@ private:
   void ClearData();
 
   std::vector< ToolTrajectory > ToolTrajectories;
+  vtkMRMLTableNode* MetricsNode;
+
+  void FindOrCreateMetricsNode( vtkMRMLTransformBufferNode* bufferNode );
 
   double PlaybackTime;
 };

--- a/Logic/vtkSlicerPerkEvaluatorLogic.h
+++ b/Logic/vtkSlicerPerkEvaluatorLogic.h
@@ -63,6 +63,9 @@ protected:
   virtual void OnMRMLSceneNodeRemoved( vtkMRMLNode* node );
 
 public:
+
+  // THIS SHOULD BE REMOVED WHEN vtkMRMLTableNode is properly added to Slicer
+  vtkMRMLTableNode* AddTable(const char* fileName, const char* name = 0);
   
   void UpdateToolTrajectories( vtkMRMLTransformBufferNode* bufferNode );
   vtkMRMLTransformBufferNode* GetSelfAndParentTransformBuffer( vtkMRMLLinearTransformNode* transform );

--- a/MRML/CMakeLists.txt
+++ b/MRML/CMakeLists.txt
@@ -32,6 +32,7 @@ set(module_mrml_target_libraries
   ${ITK_LIBRARIES}
   ${MRML_LIBRARIES}
   SlicerBaseLogic
+  vtkIOInfovis
   vtkSlicerTransformRecorderModuleMRML
   )
 

--- a/MRML/CMakeLists.txt
+++ b/MRML/CMakeLists.txt
@@ -20,10 +20,15 @@ set(module_mrml_include_directories
 set(module_mrml_SRCS
   vtkMRMLPerkEvaluatorNode.cxx
   vtkMRMLPerkEvaluatorNode.h
+  vtkMRMLTableNode.cxx
+  vtkMRMLTableNode.h
+  vtkMRMLTableStorageNode.cxx
+  vtkMRMLTableStorageNode.h
   )
 
 # Additional Target libraries
 set(module_mrml_target_libraries
+  ${VTK_LIBRARIES}
   ${ITK_LIBRARIES}
   ${MRML_LIBRARIES}
   SlicerBaseLogic

--- a/MRML/vtkMRMLTableNode.cxx
+++ b/MRML/vtkMRMLTableNode.cxx
@@ -1,0 +1,133 @@
+/*=auto=========================================================================
+
+Portions (c) Copyright 2009 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+Program:   3D Slicer
+Module:    $RCSfile: vtkMRMLTableNode.cxx,v $
+Date:      $Date: 2006/03/17 15:10:10 $
+Version:   $Revision: 1.2 $
+
+=========================================================================auto=*/
+
+// MRML includes
+#include "vtkMRMLTableNode.h"
+#include "vtkMRMLTableStorageNode.h"
+
+// VTK includes
+#include <vtkTable.h>
+#include <vtkObjectFactory.h>
+
+// STD includes
+#include <sstream>
+
+//------------------------------------------------------------------------------
+vtkCxxSetObjectMacro(vtkMRMLTableNode, Table, vtkTable)
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLTableNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLTableNode::vtkMRMLTableNode()
+{
+  this->Table = vtkTable::New();
+
+  this->HideFromEditorsOff();
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLTableNode::~vtkMRMLTableNode()
+{
+  if (this->Table)
+    {
+    this->Table->Delete();
+    this->Table = NULL;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+void vtkMRMLTableNode::WriteXML(ostream& of, int nIndent)
+{
+
+  // Start by having the superclass write its information
+  Superclass::WriteXML(of, nIndent);
+}
+
+
+//----------------------------------------------------------------------------
+void vtkMRMLTableNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  vtkMRMLNode::ReadXMLAttributes(atts);
+
+  this->EndModify(disabledModify);
+}
+
+
+//----------------------------------------------------------------------------
+// Copy the node's attributes to this object.
+// 
+void vtkMRMLTableNode::Copy(vtkMRMLNode *anode)
+{
+  int disabledModify = this->StartModify();
+  Superclass::Copy(anode);
+  vtkMRMLTableNode *node = vtkMRMLTableNode::SafeDownCast(anode);
+  if (node)
+    {
+    this->SetTable(node->GetTable());
+    }
+  this->EndModify(disabledModify);
+}
+
+
+//----------------------------------------------------------------------------
+void vtkMRMLTableNode::ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData )
+{
+  Superclass::ProcessMRMLEvents(caller, event, callData);
+
+  //if (this->TargetPlanList && this->TargetPlanList == vtkMRMLFiducialListNode::SafeDownCast(caller) &&
+  //  event ==  vtkCommand::ModifiedEvent)
+  //  {
+  //  //this->InvokeEvent(vtkMRMLVolumeNode::ImageDataModifiedEvent, NULL);
+  //  //this->UpdateFromMRML();
+  //  return;
+  //  }
+  //
+  //if (this->TargetCompletedList && this->TargetCompletedList == vtkMRMLFiducialListNode::SafeDownCast(caller) &&
+  //  event ==  vtkCommand::ModifiedEvent)
+  //  {
+  //  //this->InvokeEvent(vtkMRMLVolumeNode::ImageDataModifiedEvent, NULL);
+  //  //this->UpdateFromMRML();
+  //  return;
+  //  }
+
+  return;
+}
+
+
+//----------------------------------------------------------------------------
+void vtkMRMLTableNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+  os << indent << "\nTable Data:";
+  if (this->GetTable())
+    {
+    os << "\n";
+    this->GetTable()->PrintSelf(os, indent.GetNextIndent());
+    }
+  else
+    {
+    os << "none\n";
+    }
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLStorageNode* vtkMRMLTableNode::CreateDefaultStorageNode()
+{
+  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLTableStorageNode::New());
+}
+

--- a/MRML/vtkMRMLTableNode.h
+++ b/MRML/vtkMRMLTableNode.h
@@ -1,0 +1,99 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2009 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Program:   3D Slicer
+  Module:    $RCSfile: vtkMRMLTableNode.h,v $
+  Date:      $Date: 2006/03/19 17:12:29 $
+  Version:   $Revision: 1.3 $
+
+=========================================================================auto=*/
+
+#ifndef __vtkMRMLTableNode_h
+#define __vtkMRMLTableNode_h
+
+#include <string>
+#include <vector>
+
+#include "vtkSlicerPerkEvaluatorModuleMRMLExport.h"
+#include "vtkMRMLStorableNode.h"
+
+// MRML Includes
+class vtkMRMLStorageNode;
+
+// VTK Includes
+class vtkTable;
+
+/// \brief MRML node to represent a table object
+///
+/// It is meant to be a replacement to the vtkMRMLDoubleArrayNode
+/// to store anything table like.
+class VTK_SLICER_PERKEVALUATOR_MODULE_MRML_EXPORT 
+vtkMRMLTableNode : public vtkMRMLStorableNode
+{
+public:
+  static vtkMRMLTableNode *New();
+  vtkTypeMacro(vtkMRMLTableNode,vtkMRMLStorableNode);
+
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+  //----------------------------------------------------------------
+  /// Standard methods for MRML nodes
+  //----------------------------------------------------------------
+
+  virtual vtkMRMLNode* CreateNodeInstance();
+
+  ///
+  /// Set node attributes
+  virtual void ReadXMLAttributes( const char** atts);
+
+  ///
+  /// Write this node's information to a MRML file in XML format.
+  virtual void WriteXML(ostream& of, int indent);
+
+  ///
+  /// Copy the node's attributes to this object
+  virtual void Copy(vtkMRMLNode *node);
+
+  ///
+  /// Get node XML tag name (like Volume, Model)
+  virtual const char* GetNodeTagName()
+    {return "Table";};
+
+  ///
+  /// Method to propagate events generated in mrml
+  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
+
+  //----------------------------------------------------------------
+  /// Get and Set Macros
+  //----------------------------------------------------------------
+  virtual void SetTable(vtkTable*);
+  vtkGetObjectMacro ( Table, vtkTable );
+
+  ///
+  /// Create default storage node or NULL if does not have one
+  virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
+
+  //----------------------------------------------------------------
+  /// Constructor and destroctor
+  //----------------------------------------------------------------
+ protected:
+  vtkMRMLTableNode();
+  ~vtkMRMLTableNode();
+  vtkMRMLTableNode(const vtkMRMLTableNode&);
+  void operator=(const vtkMRMLTableNode&);
+
+
+ protected:
+  //----------------------------------------------------------------
+  /// Data
+  //----------------------------------------------------------------
+
+  vtkTable* Table;
+};
+
+#endif
+

--- a/MRML/vtkMRMLTableStorageNode.cxx
+++ b/MRML/vtkMRMLTableStorageNode.cxx
@@ -1,0 +1,190 @@
+/*=auto=========================================================================
+
+Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+Program:   3D Slicer
+Module:    $RCSfile: vtkMRMLTableStorageNode.cxx,v $
+Date:      $Date: 2006/03/17 15:10:10 $
+Version:   $Revision: 1.6 $
+
+=========================================================================auto=*/
+
+// MRML includes
+#include "vtkMRMLTableStorageNode.h"
+#include "vtkMRMLTableNode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+#include <vtkDelimitedTextReader.h>
+#include <vtkDelimitedTextWriter.h>
+#include <vtkTable.h>
+#include <vtkStringArray.h>
+#include <vtkNew.h>
+#include <vtksys/SystemTools.hxx>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLTableStorageNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLTableStorageNode::vtkMRMLTableStorageNode()
+{
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLTableStorageNode::~vtkMRMLTableStorageNode()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTableStorageNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  vtkMRMLStorageNode::PrintSelf(os,indent);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLTableStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
+{
+  return refNode->IsA("vtkMRMLTableNode");
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLTableStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
+{
+  std::string fullName = this->GetFullNameFromFileName();
+
+  if (fullName == std::string(""))
+    {
+    vtkErrorMacro("vtkMRMLTableStorageNode: File name not specified");
+    return 0;
+    }
+
+  // cast the input node
+  vtkMRMLTableNode *tableNode =
+    vtkMRMLTableNode::SafeDownCast(refNode);
+
+  if (tableNode == NULL)
+    {
+    vtkErrorMacro("ReadData: unable to cast input node " << refNode->GetID()
+                  << " to a table (measurement) node");
+    return 0;
+    }
+
+  // check that the file exists
+  if (vtksys::SystemTools::FileExists(fullName.c_str()) == false)
+    {
+    vtkErrorMacro("ReadDataInternal: model file '" << fullName.c_str() << "' not found.");
+    return 0;
+    }
+
+  // compute file prefix
+  std::string extension = vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(fullName);
+  if( extension.empty() )
+    {
+    vtkErrorMacro("ReadData: no file extension specified: " << fullName.c_str());
+    return 0;
+    }
+
+  vtkDebugMacro("ReadDataInternal: extension = " << extension.c_str());
+
+  int result = 1;
+  try
+    {
+    if ( extension == std::string(".csv") )
+      {
+      vtkNew<vtkDelimitedTextReader> reader;
+      reader->SetFileName(fullName.c_str());
+      reader->SetFieldDelimiterCharacters(",");
+      reader->SetHaveHeaders(false);
+      reader->SetDetectNumericColumns(true);
+      reader->Update();
+      tableNode->SetTable(reader->GetOutput());
+      }
+    else
+      {
+      vtkDebugMacro("Cannot read table file '" << fullName.c_str() << "' (extension = " << extension.c_str() << ")");
+      return 0;
+      }
+    }
+  catch (...)
+    {
+    result = 0;
+    }
+
+  return result;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLTableStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
+{
+  if (this->GetFileName() == NULL)
+    {
+    vtkErrorMacro("WriteData: file name is not set");
+    return 0;
+    }
+
+  std::string fullName = this->GetFullNameFromFileName();
+  if (fullName == std::string(""))
+    {
+    vtkErrorMacro("vtkMRMLTableStorageNode: File name not specified");
+    return 0;
+    }
+
+  // cast the input node
+  vtkMRMLTableNode *tableNode =
+    vtkMRMLTableNode::SafeDownCast(refNode);
+
+  if (tableNode == NULL)
+    {
+    vtkErrorMacro("WriteData: unable to cast input node " << refNode->GetID() << " to a known table node");
+    return 0;
+    }
+
+  std::string extension = vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(fullName);
+
+  int result = 1;
+  if (extension == ".csv")
+    {
+    vtkNew<vtkDelimitedTextWriter> writer;
+    writer->SetFileName(fullName.c_str());
+    writer->SetInputData( tableNode->GetTable() );
+    try
+      {
+      writer->Write();
+      }
+    catch (...)
+      {
+      result = 0;
+      }
+    }
+  else
+    {
+    result = 0;
+    vtkErrorMacro( << "No file extension recognized: " << fullName.c_str() );
+    }
+
+  return result;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTableStorageNode::InitializeSupportedReadFileTypes()
+{
+  this->SupportedReadFileTypes->InsertNextValue("Measurement CSV (.csv)");
+  this->SupportedReadFileTypes->InsertNextValue("Text (.txt)");
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTableStorageNode::InitializeSupportedWriteFileTypes()
+{
+  this->SupportedWriteFileTypes->InsertNextValue("Measurement CSV (.csv)");
+  this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLTableStorageNode::GetDefaultWriteFileExtension()
+{
+  return "csv";
+}

--- a/MRML/vtkMRMLTableStorageNode.h
+++ b/MRML/vtkMRMLTableStorageNode.h
@@ -1,0 +1,67 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Program:   3D Slicer
+  Module:    $RCSfile: vtkMRMLTableStorageNode.h,v $
+  Date:      $Date: 2006/03/19 17:12:29 $
+  Version:   $Revision: 1.8 $
+
+=========================================================================auto=*/
+
+#ifndef __vtkMRMLTableStorageNode_h
+#define __vtkMRMLTableStorageNode_h
+
+#include "vtkSlicerPerkEvaluatorModuleMRMLExport.h"
+#include "vtkMRMLStorageNode.h"
+
+/// \brief MRML node for representing a volume storage
+///
+/// vtkMRMLTableStorageNode nodes describe the fiducial storage
+/// node that allows to read/write point data from/to file.
+class VTK_SLICER_PERKEVALUATOR_MODULE_MRML_EXPORT
+vtkMRMLTableStorageNode : public vtkMRMLStorageNode
+{
+public:
+  static vtkMRMLTableStorageNode *New();
+  vtkTypeMacro(vtkMRMLTableStorageNode,vtkMRMLStorageNode);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+  virtual vtkMRMLNode* CreateNodeInstance();
+
+  /// Get node XML tag name (like Storage, Model)
+  virtual const char* GetNodeTagName()  {return "TableStorage";};
+
+  /// Return a default file extension for writting
+  virtual const char* GetDefaultWriteFileExtension();
+
+  /// Return true if the node can be read in
+  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
+
+protected:
+  vtkMRMLTableStorageNode();
+  ~vtkMRMLTableStorageNode();
+  vtkMRMLTableStorageNode(const vtkMRMLTableStorageNode&);
+  void operator=(const vtkMRMLTableStorageNode&);
+
+  /// Initialize all the supported write file types
+  virtual void InitializeSupportedReadFileTypes();
+
+  /// Initialize all the supported write file types
+  virtual void InitializeSupportedWriteFileTypes();
+
+  /// Read data and set it in the referenced node
+  virtual int ReadDataInternal(vtkMRMLNode *refNode);
+
+  /// Write data from a  referenced node
+  virtual int WriteDataInternal(vtkMRMLNode *refNode);
+
+};
+
+#endif
+
+
+

--- a/qSlicerPerkEvaluatorModule.cxx
+++ b/qSlicerPerkEvaluatorModule.cxx
@@ -25,6 +25,11 @@
 // ExtensionTemplate includes
 #include "qSlicerPerkEvaluatorModule.h"
 #include "qSlicerPerkEvaluatorModuleWidget.h"
+#include "qSlicerTablesReader.h"
+
+#include "qSlicerNodeWriter.h"
+#include "qSlicerCoreIOManager.h"
+#include "qSlicerCoreApplication.h"
 
 //-----------------------------------------------------------------------------
 Q_EXPORT_PLUGIN2(qSlicerPerkEvaluatorModule, qSlicerPerkEvaluatorModule);
@@ -105,6 +110,7 @@ void qSlicerPerkEvaluatorModule::setup()
 {
   this->Superclass::setup();
 
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
   vtkSlicerPerkEvaluatorLogic* PerkEvaluatorLogic = vtkSlicerPerkEvaluatorLogic::SafeDownCast( this->logic() );
   qSlicerAbstractCoreModule* TransformRecorderModule = qSlicerCoreApplication::application()->moduleManager()->module("TransformRecorder");
 
@@ -112,6 +118,11 @@ void qSlicerPerkEvaluatorModule::setup()
   {
     PerkEvaluatorLogic->TransformRecorderLogic = vtkSlicerTransformRecorderLogic::SafeDownCast( TransformRecorderModule->logic() );
   }
+  
+  // Register the IO
+  app->coreIOManager()->registerIO( new qSlicerTablesReader( PerkEvaluatorLogic, this ) );
+  app->coreIOManager()->registerIO( new qSlicerNodeWriter( "PerkEvaluator", QString( "Table" ), QStringList() << "vtkMRMLTableNode", this ) );
+  
 }
 
 //-----------------------------------------------------------------------------

--- a/qSlicerPerkEvaluatorModuleWidget.cxx
+++ b/qSlicerPerkEvaluatorModuleWidget.cxx
@@ -13,6 +13,7 @@
 
 // VTK includes
 #include "vtkCommand.h"
+#include "vtkTable.h"
 
 // SlicerQt includes
 #include "qSlicerPerkEvaluatorModuleWidget.h"
@@ -222,7 +223,11 @@ void qSlicerPerkEvaluatorModuleWidget
   dialog.setValue( 10 );
 
   // Metrics table  
-  std::vector<vtkSlicerPerkEvaluatorLogic::MetricType> metrics = d->logic()->GetMetrics( peNode );
+  vtkMRMLTableNode* metricsNode = d->logic()->GetMetrics( peNode );
+  if ( metricsNode == NULL )
+  {
+    return;
+  }
 
   dialog.setValue( 80 );
   
@@ -232,16 +237,25 @@ void qSlicerPerkEvaluatorModuleWidget
 
   QStringList MetricsTableHeaders;
   MetricsTableHeaders << "Metric" << "Value";
-  d->MetricsTable->setRowCount( metrics.size() );
+  d->MetricsTable->setRowCount( metricsNode->GetTable()->GetNumberOfRows() );
   d->MetricsTable->setColumnCount( 2 );
   d->MetricsTable->setHorizontalHeaderLabels( MetricsTableHeaders );
   d->MetricsTable->horizontalHeader()->setResizeMode( QHeaderView::Stretch );
   
-  for ( int i = 0; i < metrics.size(); ++ i )
+  for ( int i = 0; i < metricsNode->GetTable()->GetNumberOfRows(); i++ )
   {
-    QTableWidgetItem* nameItem = new QTableWidgetItem( QString::fromStdString( metrics.at(i).first ) );
-    QTableWidgetItem* valueItem = new QTableWidgetItem( QString::number( metrics.at(i).second, 'f', 2 ) );
+    QString nameString;
+    nameString = nameString + QString( metricsNode->GetTable()->GetValueByName( i, "TransformName" ).ToString() );
+    nameString = nameString + QString( " " );
+    nameString = nameString + QString( metricsNode->GetTable()->GetValueByName( i, "MetricName" ).ToString() );
+    QTableWidgetItem* nameItem = new QTableWidgetItem( nameString );
     d->MetricsTable->setItem( i, 0, nameItem );
+
+    QString valueString;
+    valueString = valueString + QString( metricsNode->GetTable()->GetValueByName( i, "MetricValue" ).ToString() );
+    valueString = valueString + QString( " " );
+    valueString = valueString + QString( metricsNode->GetTable()->GetValueByName( i, "MetricUnit" ).ToString() );
+    QTableWidgetItem* valueItem = new QTableWidgetItem( valueString );    
     d->MetricsTable->setItem( i, 1, valueItem );
   }
 

--- a/qSlicerTablesReader.cxx
+++ b/qSlicerTablesReader.cxx
@@ -1,0 +1,123 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kevin Wang, PMH.
+  and was partially funded by OCAIRO and Sparkit.
+
+==============================================================================*/
+
+// Qt includes
+#include <QFileInfo>
+
+// SlicerQt includes
+#include "qSlicerTablesReader.h"
+
+// Logic includes
+#include "vtkSlicerPerkEvaluatorLogic.h"
+
+// MRML includes
+#include <vtkMRMLTableNode.h>
+
+// VTK includes
+#include <vtkSmartPointer.h>
+
+//-----------------------------------------------------------------------------
+class qSlicerTablesReaderPrivate
+{
+public:
+  vtkSmartPointer<vtkSlicerPerkEvaluatorLogic> Logic;
+};
+
+//-----------------------------------------------------------------------------
+qSlicerTablesReader::qSlicerTablesReader(QObject* _parent)
+  : Superclass(_parent)
+  , d_ptr(new qSlicerTablesReaderPrivate)
+{
+}
+
+//-----------------------------------------------------------------------------
+qSlicerTablesReader
+::qSlicerTablesReader(vtkSlicerPerkEvaluatorLogic* logic, QObject* _parent)
+  : Superclass(_parent)
+  , d_ptr(new qSlicerTablesReaderPrivate)
+{
+  this->setLogic(logic);
+}
+
+//-----------------------------------------------------------------------------
+qSlicerTablesReader::~qSlicerTablesReader()
+{
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerTablesReader::setLogic(vtkSlicerPerkEvaluatorLogic* logic)
+{
+  Q_D(qSlicerTablesReader);
+  d->Logic = logic;
+}
+
+//-----------------------------------------------------------------------------
+vtkSlicerPerkEvaluatorLogic* qSlicerTablesReader::logic()const
+{
+  Q_D(const qSlicerTablesReader);
+  return d->Logic.GetPointer();
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerTablesReader::description()const
+{
+  return "Table";
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIO::IOFileType qSlicerTablesReader::fileType()const
+{
+  return QString("TableFile");
+}
+
+//-----------------------------------------------------------------------------
+QStringList qSlicerTablesReader::extensions()const
+{
+  return QStringList()
+    << "Table (*.csv)"
+    ;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerTablesReader::load(const IOProperties& properties)
+{
+  Q_D(qSlicerTablesReader);
+  Q_ASSERT(properties.contains("fileName"));
+  QString fileName = properties["fileName"].toString();
+
+  QString name = QFileInfo(fileName).baseName();
+  if (properties.contains("name"))
+    {
+    name = properties["name"].toString();
+    }
+  Q_ASSERT(d->Logic);
+  vtkMRMLTableNode* node = d->Logic->AddTable(
+    fileName.toLatin1(),
+    name.toLatin1());
+  if (node)
+    {
+    this->setLoadedNodes(QStringList(QString(node->GetID())));
+    }
+  else
+    {
+    this->setLoadedNodes(QStringList());
+    }
+  return node != 0;
+}

--- a/qSlicerTablesReader.h
+++ b/qSlicerTablesReader.h
@@ -1,0 +1,60 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kevin Wang, PMH.
+  and was partially funded by OCAIRO and Sparkit.
+
+==============================================================================*/
+
+#ifndef __qSlicerTablesReader
+#define __qSlicerTablesReader
+
+// SlicerQt includes
+#include "qSlicerFileReader.h"
+
+#include "vtkSlicerPerkEvaluatorLogic.h"
+
+class qSlicerTablesReaderPrivate;
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_DoubleArray
+class qSlicerTablesReader
+  : public qSlicerFileReader
+{
+  Q_OBJECT
+public:
+  typedef qSlicerFileReader Superclass;
+  qSlicerTablesReader(QObject* parent = 0);
+  qSlicerTablesReader(vtkSlicerPerkEvaluatorLogic* logic,
+                       QObject* parent = 0);
+  virtual ~qSlicerTablesReader();
+
+  vtkSlicerPerkEvaluatorLogic* logic()const;
+  void setLogic(vtkSlicerPerkEvaluatorLogic* logic);
+
+  virtual QString description()const;
+  virtual IOFileType fileType()const;
+  virtual QStringList extensions()const;
+
+  virtual bool load(const IOProperties& properties);
+protected:
+  QScopedPointer<qSlicerTablesReaderPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerTablesReader);
+  Q_DISABLE_COPY(qSlicerTablesReader);
+};
+
+#endif


### PR DESCRIPTION
When the vtkMRMLTableNode eventually gets merged into the Slicer core, these classes will have to be removed from the Perk Evaluator.